### PR TITLE
Add B/C check

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -1,0 +1,26 @@
+name: bc-check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  backwards-compatibility-check:
+    name: Backwards Compatibility Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.0"
+      - name: "Install dependencies"
+        run: "composer install"
+      - name: "Check for BC breaks"
+        run: "vendor/bin/roave-backward-compatibility-check --format=github-actions"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, fileinfo, sodium
           coverage: xdebug
 
       - name: Setup problem matchers

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nunomaduro/larastan": "^1.0",
         "orchestra/testbench": "^6.6|^7.0",
         "phpunit/phpunit": "^9.5",
-        "roave/backward-compatibility-check": "^7.0"
+        "roave/backward-compatibility-check": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "nunomaduro/collision": "^5.10|^6.0",
         "nunomaduro/larastan": "^1.0",
         "orchestra/testbench": "^6.6|^7.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "roave/backward-compatibility-check": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Backward Compatibility Check

A tool that can be used to verify BC breaks between two versions of a PHP library.